### PR TITLE
Enable  predPrice to only the MongoDB products

### DIFF
--- a/app/_components/predPrice/PredPrice.jsx
+++ b/app/_components/predPrice/PredPrice.jsx
@@ -8,7 +8,6 @@ const PredPrice = ({ productId, initialPredPrice }) => {
   const [prevPredPrice, setPrevPredPrice] = useState(initialPredPrice);
 
   useEffect(() => {
-    if(String(productId) ===  '98796'){
       const fetchUpdatedPredPrice = async () => {
         try {
           const response = await axios.post("/api/getPredPrice", { productId });
@@ -21,10 +20,9 @@ const PredPrice = ({ productId, initialPredPrice }) => {
         }
       };
       fetchUpdatedPredPrice()
-      //const intervalId = setInterval(fetchUpdatedPredPrice, 3000);
+      const intervalId = setInterval(fetchUpdatedPredPrice, 3000);
 
-      //return () => clearInterval(intervalId);
-    }
+      return () => clearInterval(intervalId);
   }, [productId, predPrice]);
 
   const arrowDirection = predPrice > prevPredPrice ? '/arrow_down.png' : predPrice < prevPredPrice ? '/arrow_up.png' : null;

--- a/app/_components/predPrice/PredPrice.jsx
+++ b/app/_components/predPrice/PredPrice.jsx
@@ -8,21 +8,23 @@ const PredPrice = ({ productId, initialPredPrice }) => {
   const [prevPredPrice, setPrevPredPrice] = useState(initialPredPrice);
 
   useEffect(() => {
-    const fetchUpdatedPredPrice = async () => {
-      try {
-        const response = await axios.post("/api/getPredPrice", { productId });
-        const newPredPrice = response.data.pred_price.toFixed(2);
-        setPrevPredPrice(predPrice);
-        setPredPrice(newPredPrice);
-       // console.log(newPredPrice);
-      } catch (error) {
-        console.error("Failed to fetch updated predicted price:", error);
-      }
-    };
+    if(String(productId) ===  '98796'){
+      const fetchUpdatedPredPrice = async () => {
+        try {
+          const response = await axios.post("/api/getPredPrice", { productId });
+          const newPredPrice = response.data.pred_price.toFixed(2);
+          setPrevPredPrice(predPrice);
+          setPredPrice(newPredPrice);
+         // console.log(newPredPrice);
+        } catch (error) {
+          console.error("Failed to fetch updated predicted price:", error);
+        }
+      };
+      fetchUpdatedPredPrice()
+      //const intervalId = setInterval(fetchUpdatedPredPrice, 3000);
 
-    const intervalId = setInterval(fetchUpdatedPredPrice, 3000);
-
-    return () => clearInterval(intervalId);
+      //return () => clearInterval(intervalId);
+    }
   }, [productId, predPrice]);
 
   const arrowDirection = predPrice > prevPredPrice ? '/arrow_down.png' : predPrice < prevPredPrice ? '/arrow_up.png' : null;

--- a/app/_components/predPrice/PredPrice.jsx
+++ b/app/_components/predPrice/PredPrice.jsx
@@ -19,7 +19,7 @@ const PredPrice = ({ productId, initialPredPrice }) => {
           console.error("Failed to fetch updated predicted price:", error);
         }
       };
-      fetchUpdatedPredPrice()
+      
       const intervalId = setInterval(fetchUpdatedPredPrice, 3000);
 
       return () => clearInterval(intervalId);

--- a/app/_components/productCard/ProductCard.jsx
+++ b/app/_components/productCard/ProductCard.jsx
@@ -72,8 +72,9 @@ const ProductCard = ({ id, photo, name, brand, price, pred_price, items }) => {
             <img src={photo} alt={name} width={200} height={200}></img>
             <Label className={styles.productName}>{name}</Label>
             <Description>{brand}</Description>
-
-            <PredPrice productId={id} initialPredPrice={pred_price} />
+            {
+              brand === 'MongoDB' && <PredPrice productId={id} initialPredPrice={pred_price}  />
+            }
           </div>
 
           <div className={styles.cardFooter}>

--- a/app/_components/productList/ProductList.jsx
+++ b/app/_components/productList/ProductList.jsx
@@ -4,10 +4,9 @@ import React, { useState, useEffect } from "react";
 import axios from "axios";
 import ProductCard from "../productCard/ProductCard";
 import styles from "./productList.module.css";
-import PredPrice from "../predPrice/PredPrice";
 import Pagination from "@leafygreen-ui/pagination";
 
-const itemsPerPage = 10;
+const itemsPerPage = 20;
 
 const ProductList = ({ filters }) => {
   const [filteredProducts, setFilteredProducts] = useState([]);
@@ -69,7 +68,7 @@ const ProductList = ({ filters }) => {
       <Pagination
         currentPage={currentPage}
         itemsPerPage={itemsPerPage}
-        itemsPerPageOptions={[8, 16, 32]}
+        //itemsPerPageOptions={[8, 16, 32]}
         numTotalItems={paginationLength}
         onForwardArrowClick={ () => setCurrentPage(currentPage + 1) }
         onBackArrowClick={ () => setCurrentPage(currentPage - 1) }

--- a/app/_components/sideBar/SideBar.jsx
+++ b/app/_components/sideBar/SideBar.jsx
@@ -116,7 +116,7 @@ function Sidebar({ filters, onFilterChange }) {
           {/*console.log(facets?.[0]?.facet?.brand?.buckets)*/}
 
           <div className={styles.checkboxList}>
-            {facets?.[0]?.brands?.map((bucket) => (
+            {facets?.[0]?.facet?.brand?.buckets?.map((bucket) => (
               <Checkbox
                 key={bucket._id}
                 label={`${bucket._id} (${bucket.count})`}

--- a/app/_components/sideBar/SideBar.jsx
+++ b/app/_components/sideBar/SideBar.jsx
@@ -116,7 +116,7 @@ function Sidebar({ filters, onFilterChange }) {
           {/*console.log(facets?.[0]?.facet?.brand?.buckets)*/}
 
           <div className={styles.checkboxList}>
-            {facets?.[0]?.facet?.brand?.buckets?.map((bucket) => (
+            {facets?.[0]?.brands?.map((bucket) => (
               <Checkbox
                 key={bucket._id}
                 label={`${bucket._id} (${bucket.count})`}

--- a/app/api/getFacets/route.js
+++ b/app/api/getFacets/route.js
@@ -4,28 +4,27 @@ import { connectToDatabase } from "../../_db/connect";
 export async function GET() {
     const db = await connectToDatabase();
     const collection = db.collection("products");
-    const facets = await collection.aggregate([
-        {
-            $searchMeta: {
-                index: "facets",
-                facet: {
-                    facets: {
-                        brand: {
-                            type: "string",
-                            path: "brand",
-                        },
-
-                        masterCategory: {
-                            type: "string",
-                            path: "masterCategory",
+    const pipeline = [
+            {
+                $searchMeta: {
+                    index: "facets",
+                    facet: {
+                        facets: {
+                            brand: {
+                                type: "string",
+                                path: "brand",
+                                numBuckets: 200 // Set this to a higher number to get more unique values
+                            },
+                            masterCategory: {
+                                type: "string",
+                                path: "masterCategory",
+                                numBuckets: 200 // Set this to a higher number to get more unique values
+                            },
                         },
                     },
                 },
             },
-        },
-    ]).toArray();
-    console.log('facets', facets)
-    return NextResponse.json({ facets }, { status: 200 });
-
-
+        ]
+    const result = await collection.aggregate(pipeline).toArray();
+    return NextResponse.json({ facets: result }, { status: 200 });
 }

--- a/app/api/getFacets/route.js
+++ b/app/api/getFacets/route.js
@@ -24,7 +24,7 @@ export async function GET() {
             },
         },
     ]).toArray();
-
+    console.log('facets', facets)
     return NextResponse.json({ facets }, { status: 200 });
 
 

--- a/microservices/dynamicPricing/generator.py
+++ b/microservices/dynamicPricing/generator.py
@@ -31,7 +31,7 @@ topic_path = publisher.topic_path(GOOGLE_CLOUD_PROJECT, PUBSUB_TOPIC_ID)
 
 def fetch_products():
     """Fetch products from MongoDB"""
-    return list(products_collection.find({"id": 98796}))
+    return list(products_collection.find({}) # use {"id": 98796} if you wish to debugg for just one prod
 
 def generate_ecommerce_behavior(product):
     print(product)

--- a/microservices/dynamicPricing/generator.py
+++ b/microservices/dynamicPricing/generator.py
@@ -10,6 +10,7 @@ from datetime import datetime, timedelta
 import json
 from bson import ObjectId
 import hashlib
+import certifi
 
 # Load environment variables
 load_dotenv()
@@ -19,7 +20,7 @@ GOOGLE_CLOUD_PROJECT = os.getenv('GOOGLE_CLOUD_PROJECT')
 PUBSUB_TOPIC_ID = os.getenv('PUBSUB_TOPIC_ID')
 
 # Initialize MongoDB client
-mongo_client = pymongo.MongoClient(MONGODB_URI)
+mongo_client = pymongo.MongoClient(MONGODB_URI, tlsCAFile=certifi.where())
 db = mongo_client["dotLocalStore"]
 behaviors_collection = db["events"]
 products_collection = db["products"]
@@ -30,9 +31,10 @@ topic_path = publisher.topic_path(GOOGLE_CLOUD_PROJECT, PUBSUB_TOPIC_ID)
 
 def fetch_products():
     """Fetch products from MongoDB"""
-    return list(products_collection.find({}))
+    return list(products_collection.find({"id": 98796}))
 
 def generate_ecommerce_behavior(product):
+    print(product)
     """Generate a single synthetic ecommerce behavior data for a given product"""
     # Encode product_name into a numerical field
     encoded_name = int(hashlib.sha256(product["name"].encode('utf-8')).hexdigest(), 16) % 10**8


### PR DESCRIPTION
This is a quick fix prior to implementing change streams to dynamic pricing.
What this PR does is to enable predPrice only to MongoDB products to prevent thousands of extra calls to that api.